### PR TITLE
Include filters and examples

### DIFF
--- a/src/examples/includes/IncludeGroovyTemplate.groovy
+++ b/src/examples/includes/IncludeGroovyTemplate.groovy
@@ -1,0 +1,63 @@
+#!/usr/bin/env groovy
+
+import com.github.dfrommi.pandoc.Pandoc
+import com.github.dfrommi.pandoc.convert.PandocConverter
+import com.github.dfrommi.pandoc.convert.JsonToPandocTypeConverter
+import com.github.dfrommi.pandoc.types.*
+import com.att.ecomp.dcae.doc.MarkdownUtils
+
+//
+// This filter allows you to include Groovy templates in your markdown:
+//     ```include-gtp
+//     mytemplate.gt
+//     ```
+// The output of mytemplate.gt will be, in turn, fed through the pandoc
+// AST, which means that templates can include other filters.
+//
+// To use it, make sure the gt-preprocess.groovy script is in your path and
+// that it's executable
+//
+// 
+
+Pandoc.toJSONFilter(CodeBlock) { CodeBlock cb ->
+	if ("include-gtp" in cb.attr.classes) {
+		def replacement = ""
+
+		cb.code.eachLine { l ->
+			l = l.trim()
+			// Preprocess the file first into a temp file
+			File.createTempFile("temp", ".tmp").with {
+				// Don't need it when we're done
+				it.deleteOnExit()
+
+				System.err << "Processing groovy template ${l}\n"
+
+				Process proc = "gt-preprocess.groovy ${l}".execute()
+				def sout = new StringBuffer()
+				def serr = new StringBuffer()
+
+				proc.consumeProcessOutput(sout, serr)
+				proc.waitFor()
+
+
+				if(serr.size() > 0) {
+					System.err << "WARNING: gtp produced stderr ${serr.toString()}\n"
+				}
+
+				it.write sout.toString()
+
+				if (proc.exitValue() != 0) {
+					System.err << "WARNING: gtp ${l} exited with ${proc.exitValue()}\n"
+				}
+
+				replacement = replacement + it.text
+			}
+		}
+
+		def PandocConverter converter = Pandoc.factory.getConverter()
+		def rawJson = converter.jsonTextToJson(converter.mdToJsonText(replacement))
+		def doc = converter.jsonToDocument(rawJson)
+
+		doc[1]
+	}
+}

--- a/src/examples/includes/IncludeRecurse.groovy
+++ b/src/examples/includes/IncludeRecurse.groovy
@@ -1,0 +1,58 @@
+#!/usr/bin/env groovy
+
+import com.github.dfrommi.pandoc.Pandoc
+import com.github.dfrommi.pandoc.convert.PandocConverter
+import com.github.dfrommi.pandoc.convert.JsonToPandocTypeConverter
+import com.github.dfrommi.pandoc.types.*
+
+
+//
+// This filter allows you to include other markdown files in
+// your markdown. It supports 3 levels of inclusion, which means
+// your includes can include markdown.
+//
+// To get more levels of inclusion, simply chain include filters
+// on the command line via pandoc:
+//
+// E.g.
+//    pandoc --filter IncludeRecurse.groovy --filter IncludeRecurse.groovy
+//
+// You can include as many as you need.
+//
+
+includeClosure = {
+	if (it in CodeBlock) {
+		def cb = it as CodeBlock
+		if ("include" in cb.attr.classes) {
+			def replacement = ""
+			cb.code.eachLine { l ->
+				l = l.trim()	
+				def f = new File(l)
+				replacement = replacement + f.text + "\n"
+			}
+			
+			def PandocConverter converter = Pandoc.factory.getConverter()
+			def rawJson = converter.jsonTextToJson(converter.mdToJsonText(replacement))
+			def doc = converter.jsonToDocument(rawJson)
+      
+		  return doc[1]
+		}
+	}
+	return it
+}
+
+// Triple include
+def pandoc = new Pandoc()
+def (meta, elements) = pandoc.factory.getConverter().jsonTextToDocument(System.in.text)
+def res = pandoc.factory.getFilter().walk(elements, meta, includeClosure)
+def jsonRes = pandoc.factory.getConverter().documentToJsonText([meta, res])
+
+(meta, elements) = pandoc.factory.getConverter().jsonTextToDocument(jsonRes)
+res = pandoc.factory.getFilter().walk(elements, meta, includeClosure)
+jsonRes = pandoc.factory.getConverter().documentToJsonText([meta, res])
+
+(meta, elements) = pandoc.factory.getConverter().jsonTextToDocument(jsonRes)
+res = pandoc.factory.getFilter().walk(elements, meta, includeClosure)
+jsonRes = pandoc.factory.getConverter().documentToJsonText([meta, res])
+
+print jsonRes

--- a/src/examples/includes/example_gt_include.md
+++ b/src/examples/includes/example_gt_include.md
@@ -1,0 +1,9 @@
+# Groovy template processing
+
+This file contains an `include-gtp` code block, which passes each file referenced in the block through a simple groovy template engine. To use it, make sure the groovy-pandoc jar file is in your path and then:
+
+`pandoc -f markdown -t markdown --filter ./IncludeGroovyTemplate.groovy example_gt_include.md`
+
+```include-gtp
+mygroovytemplate.gt
+```

--- a/src/examples/includes/example_recurse.md
+++ b/src/examples/includes/example_recurse.md
@@ -1,0 +1,9 @@
+# My Header
+
+Below this is an include block. Every file listed in the include block will be included inline and then run through the include filter 3 times, allowing for 3 levels of inclusion.
+
+To run it, make sure the groovy-pandoc jar is in your path and then: `pandoc -f markdown -t markdown --filter ./IncludeRecurse.groovy example_recurse.md`
+
+```include
+firstinclude.md
+```

--- a/src/examples/includes/firstinclude.md
+++ b/src/examples/includes/firstinclude.md
@@ -1,0 +1,7 @@
+## firstinclude.md
+
+This content is coming from firstinclude.md.
+
+```include
+secondinclude.md
+```

--- a/src/examples/includes/gt-preprocess.groovy
+++ b/src/examples/includes/gt-preprocess.groovy
@@ -1,0 +1,25 @@
+#!/usr/bin/env groovy
+
+import groovy.text.SimpleTemplateEngine
+
+//
+// This script passes a groovy template through the
+// StreamingTemplateEngine whether presented as input
+// on stdin or as a file
+//
+
+def engine = new groovy.text.SimpleTemplateEngine()
+def tmplt
+
+if (args.length == 1) {
+	tmplt = engine.createTemplate(new File(args[0])).make()
+	//System.err << "Processing Groovy template ${args[0]}\n"
+}
+else {
+	tmplt = engine.createTemplate(new BufferedReader(new InputStreamReader(System.in))).make()
+	//System.err << "Processing Groovy template on STDIN\n"
+}
+
+
+println tmplt.toString()
+

--- a/src/examples/includes/mygroovytemplate.gt
+++ b/src/examples/includes/mygroovytemplate.gt
@@ -1,0 +1,15 @@
+#My Groovy Template
+
+This is coming from inside a groovy template.
+
+<%
+System.out << "Hello from Groovy. A templating system is a powerful documentation tool.\n\n"
+
+(0..5).each { n ->
+%>
+
+Count is ${n}
+
+<%
+}
+%>

--- a/src/examples/includes/secondinclude.md
+++ b/src/examples/includes/secondinclude.md
@@ -1,0 +1,7 @@
+### secondinclude.md
+
+This content is coming from secondinclude.md
+
+```include
+thirdinclude.md
+```

--- a/src/examples/includes/thirdinclude.md
+++ b/src/examples/includes/thirdinclude.md
@@ -1,0 +1,3 @@
+#### thirdinclude.md
+
+This content is coming from thirdinclude.md


### PR DESCRIPTION
I've added two include filters that I have found quite useful. The first is a recursive include (to 3 levels of recursion) that allows includes to have includes (which can have includes). At some point, I will add the ability to manipulate heading levels in included files.

The second is a filter that allows you to include groovy templates, so you can programatically create markdown that will be filtered by groovy-pandoc as part of the filter (as opposed to piping the output to another instance of pandoc). I have found templates necessary when building large documentation projects that include references to YAML files, etc.

Also added examples on how to use each.
