### PR TITLE
Fixed null pointer exception in the includes example

### DIFF
--- a/src/examples/includes/Include.groovy
+++ b/src/examples/includes/Include.groovy
@@ -21,7 +21,7 @@ toJSONFilter(CodeBlock) { CodeBlock cb, meta ->
   def result = [cb]
 
   while (result.any {isIncludeBlock(it)}) {
-    result = result.collectMany { isIncludeBlock(it) ? converter.mdToDocument(includeFiles(it.code))[1] : [it] }
+    result = result.collectMany { isIncludeBlock(it) ? converter.mdToDocument(includeFiles(it.code))['blocks'] : [it] }
   }
 
   result


### PR DESCRIPTION
Changed [1] to ['block'] because the result of mdToDocument call was a hash and not an array.